### PR TITLE
[修复评论功能]修改为官网建议的评论添加功能

### DIFF
--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -1,0 +1,42 @@
+<!-- Add copied contents from original content.html here -->
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% if page.edit_url %}
+<a href="{{ page.edit_url }}" title="{{ lang.t('edit.link.title') }}" class="md-content__button md-icon">
+  {% include ".icons/material/pencil.svg" %}
+</a>
+{% endif %}
+{% if not "\x3ch1" in page.content %}
+  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+{% endif %}
+{{ page.content }}
+{% if page and page.meta and (
+  page.meta.git_revision_date_localized or
+  page.meta.revision_date
+) %}
+  {% include "partials/source-file.html" %}
+{% endif %}
+
+<!-- Get setting from mkdocs.yml, but allow page-level overrides -->
+{% set disqus = config.extra.disqus %}
+{% if page and page.meta and page.meta.disqus is string %}
+  {% set disqus = page.meta.disqus %}
+{% endif %}
+
+<!-- Inject Disqus into current page -->
+{% if disqus %}
+  <script src="https://giscus.app/client.js"
+          data-repo="shenhao-stu/comments-for-awesome-courses"
+          data-repo-id="R_kgDOGcNbZg"
+          data-category="General"
+          data-category-id="DIC_kwDOGcNbZs4CAEg3"
+          data-mapping="pathname"
+          data-reactions-enabled="1"
+          data-emit-metadata="0"
+          data-theme="light"
+          data-lang="zh-CN"
+          crossorigin="anonymous"
+          async>
+  </script>
+{% endif %}

--- a/人工智能/StanfordCS224N自然语言处理/README.md
+++ b/人工智能/StanfordCS224N自然语言处理/README.md
@@ -1,0 +1,82 @@
+课号：[CS224N](http://web.stanford.edu/class/cs224n/)
+
+教授：[Christopher Manning](https://nlp.stanford.edu/~manning/) & [John Hewitt](https://nlp.stanford.edu/~johnhew/)
+
+评论贡献者：[Hao Shen](https://github.com/shenhao-stu)
+
+- [x] Videos [bilibili](https://www.bilibili.com/video/BV11b4y1q7sZ), [Youtube](https://www.youtube.com/playlist?list=PLoROMvodv4rOSH4v6133s9LFPRHjEmbmJ)
+- [x] [Projects x N](http://web.stanford.edu/class/cs224n/project.html)
+- [x] [Assigments x 5](http://web.stanford.edu/class/cs224n/index.html#schedule)
+- [x] [Course Details](https://see.stanford.edu/Course/CS224N#course-details)
+- [x] [Complete Notes & Slides](http://web.stanford.edu/class/cs224n/index.html#schedule)
+
+## 课程信息
+
+自然语言处理（NLP）是人工智能重要的组成部分。从网络搜索、广告、电子邮件到客户服务、语言翻译、虚拟代理、医疗报告等，NLP 的应用几乎无处不在。近年来，深度学习方法在许多 NLP 任务上获得了非常高的性能。
+
+而这门课程旨在向学习者介绍自然语言处理(NLP)的基本概念和思想，全面了解NLP深度学习的前沿研究。同时，通过讲座、作业和期末专题，学习者将学习设计、完成和理解自己的神经网络模型的必要技能。
+
+这门课程涉及的主题包括：词向量；RNN，Seq2Seq；机器翻译，注意力机制；Transformer 和预训练模型；问答系统；自然语言生成；T5 和大型语言模型等。
+
+## 适合人群
+
+对自然语言处理感兴趣，想要入门的同学。
+
+## 先修条件
+
+- 能熟练使用Python（最好会使用Numpy和Pytorch库）
+- 线性代数和概率论的课程
+- 有一定机器学习的基础
+
+PS：个人觉得只要接触过机器学习的课程（推荐[吴恩达](https://www.coursera.org/learn/machine-learning)和[李宏毅](https://speech.ee.ntu.edu.tw/~hylee/ml/2021-spring.html)老师的课程），学这门课都没难度。
+
+以下是官方的prerequisites.
+
+> - Proficiency in Python
+>
+>   All class assignments will be in Python (using [NumPy](https://numpy.org/) and [PyTorch](https://pytorch.org/)). If you need to remind yourself of Python, or you're not very familiar with NumPy, you can come to the Python review session in week 1 (listed in the [schedule](http://web.stanford.edu/class/cs224n/index.html#schedule)). If you have a lot of programming experience but in a different language (e.g. C/C++/Matlab/Java/Javascript), you will probably be fine.
+>
+> - College Calculus, Linear Algebra (e.g. MATH 51, CME 100)
+>
+>   You should be comfortable taking (multivariable) derivatives and understanding matrix/vector notation and operations.
+>
+> - Basic Probability and Statistics(e.g. CS 109 or equivalent)
+>
+>   You should know basics of probabilities, gaussian distributions, mean, standard deviation, etc.
+>
+> - Foundations of Machine Learning (e.g. CS221, CS229, or CS230)
+>
+>   We will be formulating cost functions, taking derivatives and performing optimization with gradient descent. If you already have basic machine learning and/or deep learning knowledge, the course will be easier; however it is possible to take CS224n without it. There are many introductions to ML, in webpage, book, and video form. One approachable introduction is Hal Daumé’s in-progress [*A Course in Machine Learning*](http://ciml.info/). Reading the first 5 chapters of that book would be good background. Knowing the first 7 chapters would be even better!
+
+## 课程评价
+
+- Christopher Manning 不用多说，学术和讲课水平一致。
+
+> Christopher Manning 是斯坦福大学 AI 实验室主任、人工智能和计算语言学领域的权威专家。他曾先后在卡内基梅隆大学、悉尼大学等任教，1999 年回到母校斯坦福，就职于计算机科学和语言学系，是斯坦福自然语言处理组（Stanford NLP Group）的创始成员及负责人。
+
+- 课程设计包括了NLP领域中绝大部分的内容，同时官网也提供了很多的阅读资料，符合各类人群的需求。
+
+> The following texts are useful, but none are required. All of them can be read free online.
+>
+> - Dan Jurafsky and James H. Martin. [Speech and Language Processing (3rd ed. draft)](https://web.stanford.edu/~jurafsky/slp3/)
+> - Jacob Eisenstein. [Natural Language Processing](https://github.com/jacobeisenstein/gt-nlp-class/blob/master/notes/eisenstein-nlp-notes.pdf)
+> - Yoav Goldberg. [A Primer on Neural Network Models for Natural Language Processing](http://u.cs.biu.ac.il/~yogo/nnlp.pdf)
+> - Ian Goodfellow, Yoshua Bengio, and Aaron Courville. [Deep Learning](http://www.deeplearningbook.org/)
+> - Delip Rao and Brian McMahan. [Natural Language Processing with PyTorch](http://library.stanford.edu/sfx?genre=book&atitle=&title=Natural language processing with PyTorch : build intelligent language applications using deep learning /&isbn=9781491978207&volume=&issue=&date=20190101&aulast=Rao, Delip,, author.&spage=&pages=&sid=EBSCO:VLeBooks:edsvle.AH35866319) (requires Stanford login).
+>
+> If you have no background in neural networks but would like to take the course anyway, you might well find one of these books helpful to give you more background:
+>
+> - Michael A. Nielsen. [Neural Networks and Deep Learning](http://neuralnetworksanddeeplearning.com/)
+> - Eugene Charniak. [Introduction to Deep Learning](https://mitpress.mit.edu/books/introduction-deep-learning)
+
+- 课程作业内容有一定的难度，且贴合课程内容。完整的做完作业，对本课程的理解会有很大的帮助。
+- 网络上有很多相关的作业代码参考和项目的参考~
+
+## 非官方资料推荐
+
+- 李宏毅老师 [《人类语言处理深度学习课程》](https://speech.ee.ntu.edu.tw/~hylee/dlhlp/2020-spring.html)
+- NLP-Beginner：自然语言处理入门练习 [FudanNLP](https://github.com/FudanNLP/nlp-beginner)
+
+## 后续课程推荐
+
+- 无


### PR DESCRIPTION
在python新的material包中已经没有了disqus.html文件。需要通过修改content.html的内容使用disqus。
部署方式：mkdocs gh-deploy
参考内容：https://squidfunk.github.io/mkdocs-material/setup/adding-a-comment-system/
！！建议本地尝试后，如果可行，可以进行merge ！！